### PR TITLE
sx/ssl.c: fix undefined behaviour with openssl-1.1

### DIFF
--- a/sx/ssl.c
+++ b/sx/ssl.c
@@ -124,7 +124,7 @@ static DH *sx_ssl_make_dh_params(BIGNUM *(*const get_prime)(BIGNUM *), const cha
     }
 #else
     {
-        BIGNUM *p, *g;
+        BIGNUM *p, *g = NULL;
         p = get_prime(NULL);
         BN_dec2bn(&g, gen);
 


### PR DESCRIPTION
`BN_dec2bn` in OpenSSL 1.1 requires its first argument to point to either pointer to initialised `BIGNUM` or `NULL`.
Using pointer to uninitialised pointer to `BIGNUM` is undefined behaviour causing coredumps or other memory corruption.

This change fixes missing initialisation overlooked when porting to OpenSSL 1.1 API.